### PR TITLE
Plumb healthy_panic_threshold to Envoy

### DIFF
--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -2597,6 +2597,10 @@ spec:
                     type: object
                   header:
                     type: string
+                  healthy_panic_threshold:
+                    maximum: 100
+                    minimum: 0
+                    type: number
                   policy:
                     enum:
                     - round_robin
@@ -3151,6 +3155,10 @@ spec:
                     type: object
                   header:
                     type: string
+                  healthy_panic_threshold:
+                    maximum: 100
+                    minimum: 0
+                    type: number
                   policy:
                     enum:
                     - round_robin
@@ -3892,6 +3900,10 @@ spec:
                     type: object
                   header:
                     type: string
+                  healthy_panic_threshold:
+                    maximum: 100
+                    minimum: 0
+                    type: number
                   policy:
                     enum:
                     - round_robin

--- a/pkg/api/getambassador.io/v2/common.go
+++ b/pkg/api/getambassador.io/v2/common.go
@@ -298,6 +298,31 @@ func (d SecondDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(int64(d.Seconds()))
 }
 
+// +kubebuilder:validation:Type="number"
+// +kubebuilder:validation:Minimum=0
+// +kubebuilder:validation:Maximum=100
+type Percent struct {
+	Value float64 `json:"-"`
+}
+
+func (p *Percent) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		p.Value = 0
+		return nil
+	}
+
+	var floatval float64
+	if err := json.Unmarshal(data, &floatval); err != nil {
+		return err
+	}
+	p.Value = floatval
+	return nil
+}
+
+func (p Percent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.Value)
+}
+
 // UntypedDict is relatively opaque as a Go type, but it preserves its
 // contents in a roundtrippable way.
 //

--- a/pkg/api/getambassador.io/v2/common_test.go
+++ b/pkg/api/getambassador.io/v2/common_test.go
@@ -335,3 +335,103 @@ field: { *anchor: "bar"}`, TestResource{}, `{}`, "error converting YAML to JSON:
 		})
 	}
 }
+
+func TestPercent(t *testing.T) {
+	t.Parallel()
+	type TestResource struct {
+		Field crds.Percent `json:"field,omitempty"`
+	}
+	type subtest struct {
+		inputYAML      string
+		expectedStruct TestResource
+		expectedJSON   string
+		expectedErr    string
+	}
+	subtests := map[string]subtest{
+		"empty":         {`{}`, TestResource{}, `{"field":0}`, ``},
+		"explicitEmpty": {`field:`, TestResource{}, `{"field":0}`, ``},
+		"explicitnull":  {`field: null`, TestResource{}, `{"field":0}`, ``},
+		"explicitNull":  {`field: Null`, TestResource{}, `{"field":0}`, ``},
+		"explicitNULL":  {`field: NULL`, TestResource{}, `{"field":0}`, ``},
+		"explicitTilde": {`field: ~`, TestResource{}, `{"field":0}`, ``},
+		"50.5":          {`field: 50.5`, TestResource{crds.Percent{50.5}}, `{"field":50.5}`, ``},
+		"0":             {`field: 0`, TestResource{crds.Percent{0}}, `{"field":0}`, ``},
+		"100":           {`field: 100`, TestResource{crds.Percent{100}}, `{"field":100}`, ``},
+		"decimal":       {`field: 25.75`, TestResource{crds.Percent{25.75}}, `{"field":25.75}`, ``},
+		"string":        {`field: "50%"`, TestResource{crds.Percent{0}}, `{"field":0}`, "error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field TestResource.field of type float64"},
+	}
+	for name, info := range subtests {
+		info := info // capture loop variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("YAML", func(t *testing.T) {
+				var actual TestResource
+				err := yaml.Unmarshal([]byte(info.inputYAML), &actual)
+				if info.expectedErr == "" {
+					assert.NoError(t, err)
+					assert.Equal(t, info.expectedStruct, actual)
+				} else {
+					assert.EqualError(t, err, info.expectedErr)
+				}
+			})
+
+			if info.expectedErr == "" {
+				t.Run("JSON", func(t *testing.T) {
+					actualJSON, err := json.Marshal(info.expectedStruct)
+					assert.NoError(t, err)
+					assert.Equal(t, info.expectedJSON, string(actualJSON))
+				})
+			}
+		})
+	}
+}
+
+func TestPercentPtr(t *testing.T) {
+	t.Parallel()
+	type TestResource struct {
+		Field *crds.Percent `json:"field,omitempty"`
+	}
+	type subtest struct {
+		inputYAML      string
+		expectedStruct TestResource
+		expectedJSON   string
+		expectedErr    string
+	}
+	subtests := map[string]subtest{
+		"empty":         {`{}`, TestResource{}, `{}`, ``},
+		"explicitEmpty": {`field:`, TestResource{}, `{}`, ``},
+		"explicitnull":  {`field: null`, TestResource{}, `{}`, ``},
+		"explicitNull":  {`field: Null`, TestResource{}, `{}`, ``},
+		"explicitNULL":  {`field: NULL`, TestResource{}, `{}`, ``},
+		"explicitTilde": {`field: ~`, TestResource{}, `{}`, ``},
+		"50.5":          {`field: 50.5`, TestResource{&crds.Percent{50.5}}, `{"field":50.5}`, ``},
+		"0":             {`field: 0`, TestResource{&crds.Percent{0}}, `{"field":0}`, ``},
+		"100":           {`field: 100`, TestResource{&crds.Percent{100}}, `{"field":100}`, ``},
+	}
+	for name, info := range subtests {
+		info := info // capture loop variable
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("YAML", func(t *testing.T) {
+				var actual TestResource
+				err := yaml.Unmarshal([]byte(info.inputYAML), &actual)
+				if info.expectedErr == "" {
+					assert.NoError(t, err)
+					assert.Equal(t, info.expectedStruct, actual)
+				} else {
+					assert.EqualError(t, err, info.expectedErr)
+				}
+			})
+
+			if info.expectedErr == "" {
+				t.Run("JSON", func(t *testing.T) {
+					actualJSON, err := json.Marshal(info.expectedStruct)
+					assert.NoError(t, err)
+					assert.Equal(t, info.expectedJSON, string(actualJSON))
+				})
+			}
+		})
+	}
+}

--- a/pkg/api/getambassador.io/v2/crd_mapping.go
+++ b/pkg/api/getambassador.io/v2/crd_mapping.go
@@ -412,7 +412,7 @@ type LoadBalancer struct {
 	Cookie                *LoadBalancerCookie `json:"cookie,omitempty"`
 	Header                string              `json:"header,omitempty"`
 	SourceIp              *bool               `json:"source_ip,omitempty"`
-	HealthyPanicThreshold *float64            `json:"healthy_panic_threshold,omitempty"`
+	HealthyPanicThreshold *Percent            `json:"healthy_panic_threshold,omitempty"`
 }
 
 type LoadBalancerCookie struct {

--- a/pkg/api/getambassador.io/v2/crd_mapping.go
+++ b/pkg/api/getambassador.io/v2/crd_mapping.go
@@ -408,10 +408,11 @@ type RetryPolicy struct {
 type LoadBalancer struct {
 	// +kubebuilder:validation:Enum={"round_robin","ring_hash","maglev","least_request"}
 	// +kubebuilder:validation:Required
-	Policy   string              `json:"policy,omitempty"`
-	Cookie   *LoadBalancerCookie `json:"cookie,omitempty"`
-	Header   string              `json:"header,omitempty"`
-	SourceIp *bool               `json:"source_ip,omitempty"`
+	Policy                string              `json:"policy,omitempty"`
+	Cookie                *LoadBalancerCookie `json:"cookie,omitempty"`
+	Header                string              `json:"header,omitempty"`
+	SourceIp              *bool               `json:"source_ip,omitempty"`
+	HealthyPanicThreshold *float64            `json:"healthy_panic_threshold,omitempty"`
 }
 
 type LoadBalancerCookie struct {

--- a/pkg/api/getambassador.io/v3alpha1/common.go
+++ b/pkg/api/getambassador.io/v3alpha1/common.go
@@ -240,6 +240,31 @@ func (d SecondDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(int64(d.Seconds()))
 }
 
+// +kubebuilder:validation:Type="number"
+// +kubebuilder:validation:Minimum=0
+// +kubebuilder:validation:Maximum=100
+type Percent struct {
+	Value float64 `json:"-"`
+}
+
+func (p *Percent) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		p.Value = 0
+		return nil
+	}
+
+	var floatval float64
+	if err := json.Unmarshal(data, &floatval); err != nil {
+		return err
+	}
+	p.Value = floatval
+	return nil
+}
+
+func (p Percent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.Value)
+}
+
 // UntypedDict is relatively opaque as a Go type, but it preserves its
 // contents in a roundtrippable way.
 //

--- a/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
@@ -297,10 +297,11 @@ type RetryPolicy struct {
 type LoadBalancer struct {
 	// +kubebuilder:validation:Enum={"round_robin","ring_hash","maglev","least_request"}
 	// +kubebuilder:validation:Required
-	Policy   string              `json:"policy,omitempty"`
-	Cookie   *LoadBalancerCookie `json:"cookie,omitempty"`
-	Header   string              `json:"header,omitempty"`
-	SourceIp *bool               `json:"source_ip,omitempty"`
+	Policy                string              `json:"policy,omitempty"`
+	Cookie                *LoadBalancerCookie `json:"cookie,omitempty"`
+	Header                string              `json:"header,omitempty"`
+	SourceIp              *bool               `json:"source_ip,omitempty"`
+	HealthyPanicThreshold *float64            `json:"healthy_panic_threshold,omitempty"`
 }
 
 type LoadBalancerCookie struct {

--- a/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
@@ -301,7 +301,7 @@ type LoadBalancer struct {
 	Cookie                *LoadBalancerCookie `json:"cookie,omitempty"`
 	Header                string              `json:"header,omitempty"`
 	SourceIp              *bool               `json:"source_ip,omitempty"`
-	HealthyPanicThreshold *float64            `json:"healthy_panic_threshold,omitempty"`
+	HealthyPanicThreshold *Percent            `json:"healthy_panic_threshold,omitempty"`
 }
 
 type LoadBalancerCookie struct {

--- a/python/ambassador/envoy/v3/v3cluster.py
+++ b/python/ambassador/envoy/v3/v3cluster.py
@@ -216,6 +216,24 @@ class V3Cluster(Cacheable):
 
             fields["upstream_connection_options"] = {"tcp_keepalive": keepalive_options}
 
+        # Handle load balancer configuration
+        load_balancer = cluster.get("load_balancer", None)
+        if load_balancer is not None:
+            common_lb_config = {}
+
+            # Handle healthy panic threshold
+            healthy_panic_threshold = load_balancer.get("healthy_panic_threshold", None)
+            if healthy_panic_threshold is not None:
+                # Convert percentage to Envoy's Percent type (0-100 range)
+                # Clamp to valid range and convert to integer percentage
+                threshold_percent = max(0.0, min(100.0, float(healthy_panic_threshold)))
+                common_lb_config["healthy_panic_threshold"] = {
+                    "value": threshold_percent
+                }
+
+            if common_lb_config:
+                fields["common_lb_config"] = common_lb_config
+
         self.update(fields)
 
     def get_endpoints(self, cluster: IRCluster):

--- a/python/ambassador/envoy/v3/v3cluster.py
+++ b/python/ambassador/envoy/v3/v3cluster.py
@@ -216,16 +216,13 @@ class V3Cluster(Cacheable):
 
             fields["upstream_connection_options"] = {"tcp_keepalive": keepalive_options}
 
-        # Handle load balancer configuration
         load_balancer = cluster.get("load_balancer", None)
         if load_balancer is not None:
             common_lb_config = {}
 
-            # Handle healthy panic threshold
             healthy_panic_threshold = load_balancer.get("healthy_panic_threshold", None)
             if healthy_panic_threshold is not None:
-                # Convert percentage to Envoy's Percent type (0-100 range)
-                # Clamp to valid range and convert to integer percentage
+                # Convert percentage to Envoy's Percent type (0.0-100.0 range)
                 threshold_percent = max(0.0, min(100.0, float(healthy_panic_threshold)))
                 common_lb_config["healthy_panic_threshold"] = {
                     "value": threshold_percent

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -489,18 +489,20 @@ class IRHTTPMapping(IRBaseMapping):
 
         is_valid = False
         if lb_policy in ["round_robin", "least_request"]:
-            if len(load_balancer) == 1:
-                is_valid = True
+            # For round_robin and least_request, we only need the policy.
+            # Additional fields like healthy_panic_threshold are allowed.
+            is_valid = True
         elif lb_policy in ["ring_hash", "maglev"]:
-            if len(load_balancer) == 2:
-                if "cookie" in load_balancer:
-                    cookie = load_balancer.get("cookie")
-                    if "name" in cookie:
-                        is_valid = True
-                elif "header" in load_balancer:
+            # For ring_hash and maglev, we need policy plus one of: cookie, header, or source_ip
+            # Additional fields like healthy_panic_threshold are allowed.
+            if "cookie" in load_balancer:
+                cookie = load_balancer.get("cookie")
+                if "name" in cookie:
                     is_valid = True
-                elif "source_ip" in load_balancer:
-                    is_valid = True
+            elif "header" in load_balancer:
+                is_valid = True
+            elif "source_ip" in load_balancer:
+                is_valid = True
 
         return is_valid
 

--- a/python/tests/kat/t_healthy_panic_threshold.py
+++ b/python/tests/kat/t_healthy_panic_threshold.py
@@ -66,11 +66,9 @@ load_balancer:
         yield Query(self.url(self.name + "-100percent/"))
 
     def check(self):
-        # Basic functionality test - all requests should succeed
         for result in self.results:
             assert result.status == 200
 
     def requirements(self):
-        # We need to check the Envoy configuration to verify the healthy_panic_threshold is set correctly
         yield ("url", Query(self.url("ambassador/v0/diag/?json=true&filter=errors")))
         yield ("url", Query(self.url("ambassador/v0/diag/?json=true&filter=clusters")))

--- a/python/tests/kat/t_healthy_panic_threshold.py
+++ b/python/tests/kat/t_healthy_panic_threshold.py
@@ -1,0 +1,76 @@
+from typing import Dict, Generator, Tuple, Union
+
+from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType
+from kat.harness import Query
+
+
+class HealthyPanicThresholdTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-default
+hostname: "*"
+prefix: /{self.name}-default/
+service: {self.target.path.fqdn}
+resolver: endpoint
+load_balancer:
+  policy: round_robin
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-25percent
+hostname: "*"
+prefix: /{self.name}-25percent/
+service: {self.target.path.fqdn}
+resolver: endpoint
+load_balancer:
+  policy: round_robin
+  healthy_panic_threshold: 25.0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-0percent
+hostname: "*"
+prefix: /{self.name}-0percent/
+service: {self.target.path.fqdn}
+resolver: endpoint
+load_balancer:
+  policy: round_robin
+  healthy_panic_threshold: 0.0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-100percent
+hostname: "*"
+prefix: /{self.name}-100percent/
+service: {self.target.path.fqdn}
+resolver: endpoint
+load_balancer:
+  policy: round_robin
+  healthy_panic_threshold: 100.0
+"""
+        )
+
+    def queries(self):
+        yield Query(self.url(self.name + "-default/"))
+        yield Query(self.url(self.name + "-25percent/"))
+        yield Query(self.url(self.name + "-0percent/"))
+        yield Query(self.url(self.name + "-100percent/"))
+
+    def check(self):
+        # Basic functionality test - all requests should succeed
+        for result in self.results:
+            assert result.status == 200
+
+    def requirements(self):
+        # We need to check the Envoy configuration to verify the healthy_panic_threshold is set correctly
+        yield ("url", Query(self.url("ambassador/v0/diag/?json=true&filter=errors")))
+        yield ("url", Query(self.url("ambassador/v0/diag/?json=true&filter=clusters")))

--- a/python/tests/kat/t_loadbalancer.py
+++ b/python/tests/kat/t_loadbalancer.py
@@ -145,6 +145,17 @@ load_balancer:
   policy: least_request
   cookie:
     name: test-cookie
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-10
+hostname: "*"
+prefix: /{self.name}-10/
+service: {self.target.path.fqdn}
+resolver: endpoint
+load_balancer:
+  policy: round_robin
+  healthy_panic_threshold: 25.0
 """
         )
 
@@ -159,6 +170,7 @@ load_balancer:
         yield Query(self.url(self.name + "-7/"), expected=404)
         yield Query(self.url(self.name + "-8/"))
         yield Query(self.url(self.name + "-9/"), expected=404)
+        yield Query(self.url(self.name + "-10/"))
 
 
 class GlobalLoadBalancing(AmbassadorTest):

--- a/python/tests/unit/test_cluster_options.py
+++ b/python/tests/unit/test_cluster_options.py
@@ -82,3 +82,50 @@ def test_dns_ttl_mapping():
     yaml = module_and_mapping_manifests(None, None)
     # The dns type is listed as just "type"
     _test_cluster_setting(yaml, setting="respect_dns_ttl", expected=False, exists=False)
+
+
+@pytest.mark.compilertest
+def test_healthy_panic_threshold():
+    # Test healthy_panic_threshold is configured correctly
+    yaml = module_and_mapping_manifests(None, [
+        "resolver: endpoint",
+        "load_balancer:",
+        "  policy: round_robin",
+        "  healthy_panic_threshold: 25.0"
+    ])
+    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 25.0}}, exists=True)
+
+
+@pytest.mark.compilertest
+def test_healthy_panic_threshold_zero():
+    # Test healthy_panic_threshold with 0% (disable panic mode)
+    yaml = module_and_mapping_manifests(None, [
+        "resolver: endpoint",
+        "load_balancer:",
+        "  policy: round_robin",
+        "  healthy_panic_threshold: 0.0"
+    ])
+    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 0.0}}, exists=True)
+
+
+@pytest.mark.compilertest
+def test_healthy_panic_threshold_hundred():
+    # Test healthy_panic_threshold with 100%
+    yaml = module_and_mapping_manifests(None, [
+        "resolver: endpoint",
+        "load_balancer:",
+        "  policy: round_robin",
+        "  healthy_panic_threshold: 100.0"
+    ])
+    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 100.0}}, exists=True)
+
+
+@pytest.mark.compilertest
+def test_healthy_panic_threshold_not_set():
+    # Test that common_lb_config is not set when healthy_panic_threshold is not specified
+    yaml = module_and_mapping_manifests(None, [
+        "resolver: endpoint",
+        "load_balancer:",
+        "  policy: round_robin"
+    ])
+    _test_cluster_setting(yaml, setting="common_lb_config", expected=False, exists=False)

--- a/python/tests/unit/test_cluster_options.py
+++ b/python/tests/unit/test_cluster_options.py
@@ -5,7 +5,7 @@ from tests.utils import econf_compile, econf_foreach_cluster, module_and_mapping
 
 # Tests if `setting` exists within the cluster config and has `expected` as the value for that setting
 # Use `exists` to test if you expect a setting to not exist
-def _test_cluster_setting(yaml, setting, expected, exists=True):
+def _test_cluster_setting(yaml, setting, expected, exists=True, cluster_name="cluster_httpbin_default"):
     econf = econf_compile(yaml)
 
     def check(cluster):
@@ -15,11 +15,11 @@ def _test_cluster_setting(yaml, setting, expected, exists=True):
         else:
             assert setting not in cluster
 
-    econf_foreach_cluster(econf, check)
+    econf_foreach_cluster(econf, check, name=cluster_name)
 
 
 # Tests a setting in a cluster that has it's own fields. Example: common_http_protocol_options has multiple subfields
-def _test_cluster_subfields(yaml, setting, expectations={}, exists=True):
+def _test_cluster_subfields(yaml, setting, expectations={}, exists=True, cluster_name="cluster_httpbin_default"):
     econf = econf_compile(yaml)
 
     def check(cluster):
@@ -32,7 +32,7 @@ def _test_cluster_subfields(yaml, setting, expectations={}, exists=True):
             assert key in cluster[setting]
             assert cluster[setting][key] == expected
 
-    econf_foreach_cluster(econf, check)
+    econf_foreach_cluster(econf, check, name=cluster_name)
 
 
 # Test dns_type setting in Mapping
@@ -93,7 +93,7 @@ def test_healthy_panic_threshold():
         "  policy: round_robin",
         "  healthy_panic_threshold: 25.0"
     ])
-    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 25.0}}, exists=True)
+    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 25.0}}, exists=True, cluster_name="cluster_httpbin_default_er_round_robin")
 
 
 @pytest.mark.compilertest
@@ -105,7 +105,7 @@ def test_healthy_panic_threshold_zero():
         "  policy: round_robin",
         "  healthy_panic_threshold: 0.0"
     ])
-    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 0.0}}, exists=True)
+    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 0.0}}, exists=True, cluster_name="cluster_httpbin_default_er_round_robin")
 
 
 @pytest.mark.compilertest
@@ -117,7 +117,7 @@ def test_healthy_panic_threshold_hundred():
         "  policy: round_robin",
         "  healthy_panic_threshold: 100.0"
     ])
-    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 100.0}}, exists=True)
+    _test_cluster_subfields(yaml, setting="common_lb_config", expectations={"healthy_panic_threshold": {"value": 100.0}}, exists=True, cluster_name="cluster_httpbin_default_er_round_robin")
 
 
 @pytest.mark.compilertest
@@ -128,4 +128,4 @@ def test_healthy_panic_threshold_not_set():
         "load_balancer:",
         "  policy: round_robin"
     ])
-    _test_cluster_setting(yaml, setting="common_lb_config", expected=False, exists=False)
+    _test_cluster_setting(yaml, setting="common_lb_config", expected=False, exists=False, cluster_name="cluster_httpbin_default_er_round_robin")

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -304,6 +304,7 @@ def econf_foreach_hcm(econf, fn, chain_count=2):
 
 
 def econf_foreach_cluster(econf, fn, name="cluster_httpbin_default"):
+    found_cluster = False
     for cluster in econf["static_resources"]["clusters"]:
         if cluster["name"] != name:
             continue


### PR DESCRIPTION
## Description

Adds `healthy_panic_threshold` plumbing, so that it can be passed to the underlying Envoy instance.

## Related Issues

N/A

## Testing

Unit tests

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
