### PR TITLE
Plumb Retry-gRPC-On From Envoy

### DIFF
--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -2778,6 +2778,14 @@ spec:
                     - refused-stream
                     - retriable-status-codes
                     type: string
+                  retry_grpc_on:
+                    enum:
+                    - cancelled
+                    - deadline-exceeded
+                    - internal
+                    - resource-exhausted
+                    - unavailable
+                    type: string
                 type: object
               rewrite:
                 type: string
@@ -3274,6 +3282,14 @@ spec:
                     - retriable-4xx
                     - refused-stream
                     - retriable-status-codes
+                    type: string
+                  retry_grpc_on:
+                    enum:
+                    - cancelled
+                    - deadline-exceeded
+                    - internal
+                    - resource-exhausted
+                    - unavailable
                     type: string
                 type: object
               rewrite:
@@ -4032,6 +4048,14 @@ spec:
                     - retriable-4xx
                     - refused-stream
                     - retriable-status-codes
+                    type: string
+                  retry_grpc_on:
+                    enum:
+                    - cancelled
+                    - deadline-exceeded
+                    - internal
+                    - resource-exhausted
+                    - unavailable
                     type: string
                 type: object
               rewrite:

--- a/pkg/api/getambassador.io/v2/crd_mapping.go
+++ b/pkg/api/getambassador.io/v2/crd_mapping.go
@@ -400,7 +400,9 @@ func (l OriginList) MarshalJSON() ([]byte, error) {
 
 type RetryPolicy struct {
 	// +kubebuilder:validation:Enum={"5xx","gateway-error","connect-failure","retriable-4xx","refused-stream","retriable-status-codes"}
-	RetryOn       string `json:"retry_on,omitempty"`
+	RetryOn string `json:"retry_on,omitempty"`
+	// +kubebuilder:validation:Enum={"cancelled","deadline-exceeded","internal","resource-exhausted","unavailable"}
+	RetryGrpcOn   string `json:"retry_grpc_on,omitempty"`
 	NumRetries    *int   `json:"num_retries,omitempty"`
 	PerTryTimeout string `json:"per_try_timeout,omitempty"`
 }

--- a/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
@@ -289,7 +289,9 @@ type CORS struct {
 
 type RetryPolicy struct {
 	// +kubebuilder:validation:Enum={"5xx","gateway-error","connect-failure","retriable-4xx","refused-stream","retriable-status-codes"}
-	RetryOn       string `json:"retry_on,omitempty"`
+	RetryOn string `json:"retry_on,omitempty"`
+	// +kubebuilder:validation:Enum={"cancelled","deadline-exceeded","internal","resource-exhausted","unavailable"}
+	RetryGrpcOn   string `json:"retry_grpc_on,omitempty"`
 	NumRetries    *int   `json:"num_retries,omitempty"`
 	PerTryTimeout string `json:"per_try_timeout,omitempty"`
 }

--- a/python/ambassador/ir/irretrypolicy.py
+++ b/python/ambassador/ir/irretrypolicy.py
@@ -30,9 +30,16 @@ class IRRetryPolicy(IRResource):
 
     def validate_retry_policy(self) -> bool:
         retry_on = self.get("retry_on", None)
+        retry_grpc_on = self.get("retry_grpc_on", None)
 
-        is_valid = False
-        if retry_on in {
+        # At least one of retry_on or retry_grpc_on should be specified
+        if not retry_on and not retry_grpc_on:
+            return False
+
+        is_valid = True
+
+        # Validate retry_on if specified
+        if retry_on and retry_on not in {
             "5xx",
             "gateway-error",
             "connect-failure",
@@ -40,7 +47,24 @@ class IRRetryPolicy(IRResource):
             "refused-stream",
             "retriable-status-codes",
         }:
-            is_valid = True
+            is_valid = False
+
+        # Validate retry_grpc_on if specified
+        # retry_grpc_on can be a comma-separated string
+        if retry_grpc_on:
+            valid_grpc_conditions = {
+                "cancelled",
+                "deadline-exceeded",
+                "internal",
+                "resource-exhausted",
+                "unavailable",
+            }
+            # Split on comma and validate each condition
+            grpc_conditions = [c.strip() for c in retry_grpc_on.split(",")]
+            for condition in grpc_conditions:
+                if condition not in valid_grpc_conditions:
+                    is_valid = False
+                    break
 
         return is_valid
 
@@ -60,5 +84,20 @@ class IRRetryPolicy(IRResource):
                 "metadata_labels",
             ]:
                 raw_dict.pop(key, None)
+
+        # Combine retry_on and retry_grpc_on into a single retry_on field for Envoy
+        retry_on = raw_dict.get("retry_on", "")
+        retry_grpc_on = raw_dict.get("retry_grpc_on", "")
+
+        if retry_on and retry_grpc_on:
+            # Both are specified, combine them with a comma
+            raw_dict["retry_on"] = f"{retry_on},{retry_grpc_on}"
+        elif retry_grpc_on:
+            # Only gRPC retry conditions specified
+            raw_dict["retry_on"] = retry_grpc_on
+        # If only retry_on is specified, it's already in the dict
+
+        # Remove the separate retry_grpc_on field since Envoy expects everything in retry_on
+        raw_dict.pop("retry_grpc_on", None)
 
         return raw_dict

--- a/python/tests/kat/t_retrypolicy_grpc.py
+++ b/python/tests/kat/t_retrypolicy_grpc.py
@@ -1,0 +1,155 @@
+from typing import Generator, Tuple, Union
+
+from abstract_tests import EGRPC, AmbassadorTest, Node, ServiceType
+from kat.harness import Query
+
+
+class RetryPolicyGrpcTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-grpc-retry
+hostname: "*"
+prefix: /{self.name}-grpc-retry/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+retry_policy:
+  retry_grpc_on: "unavailable"
+  num_retries: 2
+"""
+        )
+
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-combined-retry
+hostname: "*"
+prefix: /{self.name}-combined-retry/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+retry_policy:
+  retry_on: "5xx"
+  retry_grpc_on: "cancelled"
+  num_retries: 3
+"""
+        )
+
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-normal
+hostname: "*"
+prefix: /{self.name}-normal/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+"""
+        )
+
+    def queries(self):
+        # Test gRPC retry with unavailable status
+        yield Query(
+            self.url(f"{self.name}-grpc-retry/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "14"},  # UNAVAILABLE
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Test combined HTTP and gRPC retry
+        yield Query(
+            self.url(f"{self.name}-combined-retry/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "1"},  # CANCELLED
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Test normal request without retry
+        yield Query(
+            self.url(f"{self.name}-normal/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "0"},  # OK
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Check diagnostics
+        yield Query(self.url("ambassador/v0/diag/?json=true&filter=errors"), phase=2)
+
+    def check(self):
+        # Check that there are no errors in diagnostics
+        errors = self.results[-1].json
+        assert len(errors) == 0, f"Expected no errors, got: {errors}"
+
+        # Verify the gRPC responses
+        assert self.results[0].headers.get("Grpc-Status") is not None
+        assert self.results[1].headers.get("Grpc-Status") is not None
+        assert self.results[2].headers.get("Grpc-Status") == ["0"]  # OK status
+
+
+class RetryPolicyGrpcModuleTest(AmbassadorTest):
+    """Test retry_grpc_on at the Module level"""
+    target: ServiceType
+
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+name: ambassador
+config:
+  retry_policy:
+    retry_grpc_on: "resource-exhausted"
+    num_retries: 2
+"""
+        )
+
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-module-retry
+hostname: "*"
+prefix: /{self.name}-module-retry/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+"""
+        )
+
+    def queries(self):
+        # Test that module-level gRPC retry policy is applied
+        yield Query(
+            self.url(f"{self.name}-module-retry/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "8"},  # RESOURCE_EXHAUSTED
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Check diagnostics
+        yield Query(self.url("ambassador/v0/diag/?json=true&filter=errors"), phase=2)
+
+    def check(self):
+        # Check that there are no errors in diagnostics
+        errors = self.results[-1].json
+        assert len(errors) == 0, f"Expected no errors, got: {errors}"
+
+        # Verify the gRPC response
+        assert self.results[0].headers.get("Grpc-Status") is not None

--- a/python/tests/unit/test_irretrypolicy_grpc.py
+++ b/python/tests/unit/test_irretrypolicy_grpc.py
@@ -1,0 +1,227 @@
+from unittest.mock import MagicMock
+
+from ambassador.config import Config
+from ambassador.ir import IR
+from ambassador.ir.irretrypolicy import IRRetryPolicy
+
+
+class TestIRRetryPolicyGrpc:
+    def setup_method(self):
+        self.ir = MagicMock(spec=IR)
+        self.ir.ambassador_namespace = "default"
+        self.ir.logger = MagicMock()
+        self.aconf = MagicMock(spec=Config)
+
+    def test_retry_grpc_on_valid_values(self):
+        """Test that valid gRPC retry conditions are accepted"""
+        valid_grpc_conditions = [
+            "cancelled",
+            "deadline-exceeded", 
+            "internal",
+            "resource-exhausted",
+            "unavailable"
+        ]
+        
+        for condition in valid_grpc_conditions:
+            policy = IRRetryPolicy(
+                ir=self.ir,
+                aconf=self.aconf,
+                retry_grpc_on=condition
+            )
+            assert policy.validate_retry_policy() is True
+
+    def test_retry_grpc_on_invalid_values(self):
+        """Test that invalid gRPC retry conditions are rejected"""
+        invalid_grpc_conditions = [
+            "invalid-condition",
+            "5xx",  # This is an HTTP condition, not gRPC
+            "gateway-error",  # This is an HTTP condition, not gRPC
+            "unknown"
+        ]
+        
+        for condition in invalid_grpc_conditions:
+            policy = IRRetryPolicy(
+                ir=self.ir,
+                aconf=self.aconf,
+                retry_grpc_on=condition
+            )
+            assert policy.validate_retry_policy() is False
+
+    def test_retry_on_and_retry_grpc_on_both_valid(self):
+        """Test that both HTTP and gRPC retry conditions can be specified together"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_on="5xx",
+            retry_grpc_on="unavailable"
+        )
+        assert policy.validate_retry_policy() is True
+
+    def test_retry_on_valid_retry_grpc_on_invalid(self):
+        """Test that invalid gRPC condition fails validation even with valid HTTP condition"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_on="5xx",
+            retry_grpc_on="invalid-grpc-condition"
+        )
+        assert policy.validate_retry_policy() is False
+
+    def test_retry_on_invalid_retry_grpc_on_valid(self):
+        """Test that invalid HTTP condition fails validation even with valid gRPC condition"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_on="invalid-http-condition",
+            retry_grpc_on="unavailable"
+        )
+        assert policy.validate_retry_policy() is False
+
+    def test_neither_retry_condition_specified(self):
+        """Test that at least one retry condition must be specified"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            num_retries=3
+        )
+        assert policy.validate_retry_policy() is False
+
+    def test_as_dict_combines_retry_conditions(self):
+        """Test that as_dict() combines retry_on and retry_grpc_on into single retry_on field"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_on="5xx",
+            retry_grpc_on="unavailable",
+            num_retries=3
+        )
+        
+        result = policy.as_dict()
+        
+        # Should combine both conditions
+        assert result["retry_on"] == "5xx,unavailable"
+        # Should not have separate retry_grpc_on field
+        assert "retry_grpc_on" not in result
+        # Should preserve other fields
+        assert result["num_retries"] == 3
+
+    def test_as_dict_only_retry_on(self):
+        """Test that as_dict() works with only retry_on specified"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_on="gateway-error",
+            num_retries=2
+        )
+        
+        result = policy.as_dict()
+        
+        # Should keep only retry_on
+        assert result["retry_on"] == "gateway-error"
+        assert "retry_grpc_on" not in result
+        assert result["num_retries"] == 2
+
+    def test_as_dict_only_retry_grpc_on(self):
+        """Test that as_dict() works with only retry_grpc_on specified"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="cancelled",
+            num_retries=1
+        )
+        
+        result = policy.as_dict()
+        
+        # Should move retry_grpc_on to retry_on
+        assert result["retry_on"] == "cancelled"
+        assert "retry_grpc_on" not in result
+        assert result["num_retries"] == 1
+
+    def test_as_dict_removes_internal_fields(self):
+        """Test that as_dict() removes internal fields"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="internal",
+            _active=True,
+            _errored=False,
+            kind="IRRetryPolicy"
+        )
+
+        result = policy.as_dict()
+
+        # Should remove internal fields
+        assert "_active" not in result
+        assert "_errored" not in result
+        assert "kind" not in result
+        # Should keep retry condition
+        assert result["retry_on"] == "internal"
+
+    def test_retry_grpc_on_comma_separated_valid(self):
+        """Test that comma-separated valid gRPC retry conditions are accepted"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="cancelled,unavailable"
+        )
+        assert policy.validate_retry_policy() is True
+
+    def test_retry_grpc_on_comma_separated_multiple_valid(self):
+        """Test that multiple comma-separated valid gRPC retry conditions are accepted"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="cancelled,deadline-exceeded,internal,resource-exhausted,unavailable"
+        )
+        assert policy.validate_retry_policy() is True
+
+    def test_retry_grpc_on_comma_separated_with_spaces(self):
+        """Test that comma-separated gRPC retry conditions with spaces are accepted"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="cancelled, unavailable, internal"
+        )
+        assert policy.validate_retry_policy() is True
+
+    def test_retry_grpc_on_comma_separated_invalid(self):
+        """Test that comma-separated gRPC retry conditions with one invalid value are rejected"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="cancelled,invalid-condition,unavailable"
+        )
+        assert policy.validate_retry_policy() is False
+
+    def test_as_dict_comma_separated_retry_grpc_on(self):
+        """Test that as_dict() preserves comma-separated retry_grpc_on values"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_grpc_on="cancelled,unavailable",
+            num_retries=2
+        )
+
+        result = policy.as_dict()
+
+        # Should move comma-separated retry_grpc_on to retry_on
+        assert result["retry_on"] == "cancelled,unavailable"
+        assert "retry_grpc_on" not in result
+        assert result["num_retries"] == 2
+
+    def test_as_dict_combines_retry_on_with_comma_separated_retry_grpc_on(self):
+        """Test that as_dict() combines retry_on with comma-separated retry_grpc_on"""
+        policy = IRRetryPolicy(
+            ir=self.ir,
+            aconf=self.aconf,
+            retry_on="5xx",
+            retry_grpc_on="cancelled,unavailable",
+            num_retries=3
+        )
+
+        result = policy.as_dict()
+
+        # Should combine both conditions
+        assert result["retry_on"] == "5xx,cancelled,unavailable"
+        assert "retry_grpc_on" not in result
+        assert result["num_retries"] == 3


### PR DESCRIPTION
Adds [retry-grpc-on functionality from Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on). Allows use of the envoy-supported policies:

* cancelled
* deadline-exceeded
* internal
* resource-exhausted
* unavailable

Since Arista is using gRPC for CV calls, we would like to add this functionality to allow retry logic via the proxy.