### PR TITLE
goreleaser: build apiext binary and include in docker image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,17 @@ builds:
       - linux
     goarch:
       - amd64
+  - id: apiext
+    main: ./cmd/apiext
+    binary: apiext
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
 
 dockers:
   - use: buildx
@@ -34,6 +45,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
     ids:
       - busyambassador
+      - apiext
     image_templates:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Version }}"
     build_flag_templates:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -37,11 +37,13 @@ COPY python/ambassador.version /buildroot/ambassador/python/ambassador.version
 # Copy over busyambassador
 WORKDIR /opt/ambassador/bin
 COPY busyambassador busyambassador
+COPY apiext apiext
 
 # Make the symlinks we need
-RUN for name in agent apiext entrypoint kubestatus; do ln -s busyambassador $name; done && \
+RUN for name in agent entrypoint kubestatus; do ln -s busyambassador $name; done && \
     cd /usr/local/bin && \
-    for name in agent apiext busyambassador entrypoint kubestatus; do ln -s ../../../opt/ambassador/bin/busyambassador $name; done
+    for name in agent busyambassador entrypoint kubestatus; do ln -s ../../../opt/ambassador/bin/busyambassador $name; done && \
+    ln -s ../../../opt/ambassador/bin/apiext apiext
 
 # Set up for a non-root environment.
 # Always have an "ambassador" user as UID 8888. This is what we recommend


### PR DESCRIPTION
In 3.10, apiext was split as a separate binary that isn't part of busyambassador anymore. Build the binary and include it in the same iamge, so we can keep it simple for now.