### PR TITLE
charts: add missing endpointslices permission

### DIFF
--- a/charts/emissary-ingress/templates/rbac.yaml
+++ b/charts/emissary-ingress/templates/rbac.yaml
@@ -89,6 +89,10 @@ rules:
     - endpoints
     verbs: ["get", "list", "watch"]
 
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: ["get", "list", "watch"]
+
   - apiGroups: [ "getambassador.io", "gateway.getambassador.io" ]
     resources: [ "*" ]
     verbs: ["get", "list", "watch", "update", "patch", "create", "delete" ]


### PR DESCRIPTION
Backporting https://github.com/aristanetworks/emissary/commit/af5ffa9609b22f73025f7afade2b587ecc0db2d0 that wasn't part of emissary 3.10.0 release but that was merged to master after.