### PR TITLE
.gitignore: Add Test Auth to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 .*.stamp
 /docker/kat-server/server.crt
 /docker/kat-server/server.key
+/docker/test-auth/authsvc.crt
+/docker/test-auth/authsvc.key
+/docker/test-shadow/shadowsvc.crt
+/docker/test-shadow/shadowsvc.key
 
 *.pyc
 *~


### PR DESCRIPTION
The test certs/auth are annoying. They shouldn't pose any security concern, but still, they should not be committed nor pushed (accidentally) to the repo. The other .crt and .key files are already listed, but this is not all of them.