### PR TITLE
.github: Pin 24.04 in Python Unit Tests CI

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04
+  
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Pins ubuntu to 24.04 (like the other instances) to prevent pulling latest.