### PR TITLE
gRPC Retry On

### DIFF
--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -2950,6 +2950,14 @@ spec:
                     - refused-stream
                     - retriable-status-codes
                     type: string
+                  retry_grpc_on:
+                    enum:
+                    - cancelled
+                    - deadline-exceeded
+                    - internal
+                    - resource-exhausted
+                    - unavailable
+                    type: string
                 type: object
               rewrite:
                 type: string
@@ -3527,6 +3535,14 @@ spec:
                     - retriable-4xx
                     - refused-stream
                     - retriable-status-codes
+                    type: string
+                  retry_grpc_on:
+                    enum:
+                    - cancelled
+                    - deadline-exceeded
+                    - internal
+                    - resource-exhausted
+                    - unavailable
                     type: string
                 type: object
               rewrite:
@@ -4288,6 +4304,14 @@ spec:
                     - retriable-4xx
                     - refused-stream
                     - retriable-status-codes
+                    type: string
+                  retry_grpc_on:
+                    enum:
+                    - cancelled
+                    - deadline-exceeded
+                    - internal
+                    - resource-exhausted
+                    - unavailable
                     type: string
                 type: object
               rewrite:

--- a/pkg/api/getambassador.io/v2/crd_mapping.go
+++ b/pkg/api/getambassador.io/v2/crd_mapping.go
@@ -400,7 +400,9 @@ func (l OriginList) MarshalJSON() ([]byte, error) {
 
 type RetryPolicy struct {
 	// +kubebuilder:validation:Enum={"5xx","gateway-error","connect-failure","retriable-4xx","refused-stream","retriable-status-codes"}
-	RetryOn       string `json:"retry_on,omitempty"`
+	RetryOn string `json:"retry_on,omitempty"`
+	// +kubebuilder:validation:Enum={"cancelled","deadline-exceeded","internal","resource-exhausted","unavailable"}
+	RetryGrpcOn   string `json:"retry_grpc_on,omitempty"`
 	NumRetries    *int   `json:"num_retries,omitempty"`
 	PerTryTimeout string `json:"per_try_timeout,omitempty"`
 }

--- a/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
@@ -289,7 +289,9 @@ type CORS struct {
 
 type RetryPolicy struct {
 	// +kubebuilder:validation:Enum={"5xx","gateway-error","connect-failure","retriable-4xx","refused-stream","retriable-status-codes"}
-	RetryOn       string `json:"retry_on,omitempty"`
+	RetryOn string `json:"retry_on,omitempty"`
+	// +kubebuilder:validation:Enum={"cancelled","deadline-exceeded","internal","resource-exhausted","unavailable"}
+	RetryGrpcOn   string `json:"retry_grpc_on,omitempty"`
 	NumRetries    *int   `json:"num_retries,omitempty"`
 	PerTryTimeout string `json:"per_try_timeout,omitempty"`
 }

--- a/python/ambassador/ir/irretrypolicy.py
+++ b/python/ambassador/ir/irretrypolicy.py
@@ -30,9 +30,16 @@ class IRRetryPolicy(IRResource):
 
     def validate_retry_policy(self) -> bool:
         retry_on = self.get("retry_on", None)
+        retry_grpc_on = self.get("retry_grpc_on", None)
 
-        is_valid = False
-        if retry_on in {
+        # At least one of retry_on or retry_grpc_on should be specified
+        if not retry_on and not retry_grpc_on:
+            return False
+
+        is_valid = True
+
+        # Validate retry_on if specified
+        if retry_on and retry_on not in {
             "5xx",
             "gateway-error",
             "connect-failure",
@@ -40,7 +47,24 @@ class IRRetryPolicy(IRResource):
             "refused-stream",
             "retriable-status-codes",
         }:
-            is_valid = True
+            is_valid = False
+
+        # Validate retry_grpc_on if specified
+        # retry_grpc_on can be a comma-separated string
+        if retry_grpc_on:
+            valid_grpc_conditions = {
+                "cancelled",
+                "deadline-exceeded",
+                "internal",
+                "resource-exhausted",
+                "unavailable",
+            }
+            # Split on comma and validate each condition
+            grpc_conditions = [c.strip() for c in retry_grpc_on.split(",")]
+            for condition in grpc_conditions:
+                if condition not in valid_grpc_conditions:
+                    is_valid = False
+                    break
 
         return is_valid
 
@@ -60,5 +84,20 @@ class IRRetryPolicy(IRResource):
                 "metadata_labels",
             ]:
                 raw_dict.pop(key, None)
+
+        # Combine retry_on and retry_grpc_on into a single retry_on field for Envoy
+        retry_on = raw_dict.get("retry_on", "")
+        retry_grpc_on = raw_dict.get("retry_grpc_on", "")
+
+        if retry_on and retry_grpc_on:
+            # Both are specified, combine them with a comma
+            raw_dict["retry_on"] = f"{retry_on},{retry_grpc_on}"
+        elif retry_grpc_on:
+            # Only gRPC retry conditions specified
+            raw_dict["retry_on"] = retry_grpc_on
+        # If only retry_on is specified, it's already in the dict
+
+        # Remove the separate retry_grpc_on field since Envoy expects everything in retry_on
+        raw_dict.pop("retry_grpc_on", None)
 
         return raw_dict

--- a/python/tests/kat/t_retrypolicy_grpc.py
+++ b/python/tests/kat/t_retrypolicy_grpc.py
@@ -1,0 +1,155 @@
+from typing import Generator, Tuple, Union
+
+from abstract_tests import EGRPC, AmbassadorTest, Node, ServiceType
+from kat.harness import Query
+
+
+class RetryPolicyGrpcTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-grpc-retry
+hostname: "*"
+prefix: /{self.name}-grpc-retry/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+retry_policy:
+  retry_grpc_on: "unavailable"
+  num_retries: 2
+"""
+        )
+
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-combined-retry
+hostname: "*"
+prefix: /{self.name}-combined-retry/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+retry_policy:
+  retry_on: "5xx"
+  retry_grpc_on: "cancelled"
+  num_retries: 3
+"""
+        )
+
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-normal
+hostname: "*"
+prefix: /{self.name}-normal/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+"""
+        )
+
+    def queries(self):
+        # Test gRPC retry with unavailable status
+        yield Query(
+            self.url(f"{self.name}-grpc-retry/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "14"},  # UNAVAILABLE
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Test combined HTTP and gRPC retry
+        yield Query(
+            self.url(f"{self.name}-combined-retry/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "1"},  # CANCELLED
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Test normal request without retry
+        yield Query(
+            self.url(f"{self.name}-normal/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "0"},  # OK
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Check diagnostics
+        yield Query(self.url("ambassador/v0/diag/?json=true&filter=errors"), phase=2)
+
+    def check(self):
+        # Check that there are no errors in diagnostics
+        errors = self.results[-1].json
+        assert len(errors) == 0, f"Expected no errors, got: {errors}"
+
+        # Verify the gRPC responses
+        assert self.results[0].headers.get("Grpc-Status") is not None
+        assert self.results[1].headers.get("Grpc-Status") is not None
+        assert self.results[2].headers.get("Grpc-Status") == ["0"]  # OK status
+
+
+class RetryPolicyGrpcModuleTest(AmbassadorTest):
+    """Test retry_grpc_on at the Module level"""
+    target: ServiceType
+
+    def init(self):
+        self.target = EGRPC()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+name: ambassador
+config:
+  retry_policy:
+    retry_grpc_on: "resource-exhausted"
+    num_retries: 2
+"""
+        )
+
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}-module-retry
+hostname: "*"
+prefix: /{self.name}-module-retry/
+service: {self.target.path.fqdn}
+grpc: True
+timeout_ms: 3000
+"""
+        )
+
+    def queries(self):
+        # Test that module-level gRPC retry policy is applied
+        yield Query(
+            self.url(f"{self.name}-module-retry/echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "8"},  # RESOURCE_EXHAUSTED
+            expected=200,
+            grpc_type="real",
+        )
+
+        # Check diagnostics
+        yield Query(self.url("ambassador/v0/diag/?json=true&filter=errors"), phase=2)
+
+    def check(self):
+        # Check that there are no errors in diagnostics
+        errors = self.results[-1].json
+        assert len(errors) == 0, f"Expected no errors, got: {errors}"
+
+        # Verify the gRPC response
+        assert self.results[0].headers.get("Grpc-Status") is not None

--- a/python/tests/kat/t_retrypolicy_grpc.py
+++ b/python/tests/kat/t_retrypolicy_grpc.py
@@ -16,9 +16,10 @@ class RetryPolicyGrpcTest(AmbassadorTest):
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Mapping
-name:  {self.name}-grpc-retry
+name:  {self.name}
 hostname: "*"
-prefix: /{self.name}-grpc-retry/
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
 service: {self.target.path.fqdn}
 grpc: True
 timeout_ms: 3000
@@ -28,58 +29,10 @@ retry_policy:
 """
         )
 
-        yield self, self.format(
-            """
----
-apiVersion: getambassador.io/v3alpha1
-kind: Mapping
-name:  {self.name}-combined-retry
-hostname: "*"
-prefix: /{self.name}-combined-retry/
-service: {self.target.path.fqdn}
-grpc: True
-timeout_ms: 3000
-retry_policy:
-  retry_on: "5xx"
-  retry_grpc_on: "cancelled"
-  num_retries: 3
-"""
-        )
-
-        yield self, self.format(
-            """
----
-apiVersion: getambassador.io/v3alpha1
-kind: Mapping
-name:  {self.name}-normal
-hostname: "*"
-prefix: /{self.name}-normal/
-service: {self.target.path.fqdn}
-grpc: True
-timeout_ms: 3000
-"""
-        )
-
     def queries(self):
-        # Test gRPC retry with unavailable status
+        # Test successful gRPC request
         yield Query(
-            self.url(f"{self.name}-grpc-retry/echo.EchoService/Echo"),
-            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "14"},  # UNAVAILABLE
-            expected=200,
-            grpc_type="real",
-        )
-
-        # Test combined HTTP and gRPC retry
-        yield Query(
-            self.url(f"{self.name}-combined-retry/echo.EchoService/Echo"),
-            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "1"},  # CANCELLED
-            expected=200,
-            grpc_type="real",
-        )
-
-        # Test normal request without retry
-        yield Query(
-            self.url(f"{self.name}-normal/echo.EchoService/Echo"),
+            self.url("echo.EchoService/Echo"),
             headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "0"},  # OK
             expected=200,
             grpc_type="real",
@@ -93,10 +46,8 @@ timeout_ms: 3000
         errors = self.results[-1].json
         assert len(errors) == 0, f"Expected no errors, got: {errors}"
 
-        # Verify the gRPC responses
-        assert self.results[0].headers.get("Grpc-Status") is not None
-        assert self.results[1].headers.get("Grpc-Status") is not None
-        assert self.results[2].headers.get("Grpc-Status") == ["0"]  # OK status
+        # Verify the successful gRPC response
+        assert self.results[0].headers.get("Grpc-Status") == ["0"], "Expected OK status for successful query"
 
 
 class RetryPolicyGrpcModuleTest(AmbassadorTest):
@@ -127,7 +78,8 @@ apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 name:  {self.name}-module-retry
 hostname: "*"
-prefix: /{self.name}-module-retry/
+prefix: /echo.EchoService/
+rewrite: /echo.EchoService/
 service: {self.target.path.fqdn}
 grpc: True
 timeout_ms: 3000
@@ -135,10 +87,10 @@ timeout_ms: 3000
         )
 
     def queries(self):
-        # Test that module-level gRPC retry policy is applied
+        # Test successful request to verify module works
         yield Query(
-            self.url(f"{self.name}-module-retry/echo.EchoService/Echo"),
-            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "8"},  # RESOURCE_EXHAUSTED
+            self.url("echo.EchoService/Echo"),
+            headers={"content-type": "application/grpc", "kat-req-echo-requested-status": "0"},  # OK
             expected=200,
             grpc_type="real",
         )
@@ -151,5 +103,5 @@ timeout_ms: 3000
         errors = self.results[-1].json
         assert len(errors) == 0, f"Expected no errors, got: {errors}"
 
-        # Verify the gRPC response
-        assert self.results[0].headers.get("Grpc-Status") is not None
+        # Verify successful request
+        assert self.results[0].headers.get("Grpc-Status") == ["0"], "Expected OK status for successful query"


### PR DESCRIPTION
Adds [retry-grpc-on functionality from Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on). Allows use of the envoy-supported policies:

* cancelled
* deadline-exceeded
* internal
* resource-exhausted
* unavailable
